### PR TITLE
Adds newlines to the end of entries in the output file

### DIFF
--- a/Responder.py
+++ b/Responder.py
@@ -59,6 +59,7 @@ Show_Help("[+]NBT-NS & LLMNR answerer started\n")
 def WriteData(outfile,data):
     with open(outfile,"w") as outf:
          outf.write(data)
+	 outf.write("\n")
          outf.close()
 
 # Change this if needed. Currently using the same challenge as metasploit since several rainbow tables were created with that challenge.


### PR DESCRIPTION
This is so when people do "cat *" all the entries wont be strung together. There will be one entry per line. Makes parsing using shell utils much easier.
