### PR TITLE
Made Responder.py executable and changed to 2.0

### DIFF
--- a/Responder.py
+++ b/Responder.py
@@ -121,7 +121,7 @@ logger2 = logging.getLogger('LLMNR/NBT-NS')
 logger2.addHandler(logging.FileHandler(Log2Filename,'w'))
 
 def Show_Help(ExtraHelpData):
-   help = "NBT Name Service/LLMNR Answerer 1.0.\nPlease send bugs/comments to: lgaffie@trustwave.com\nTo kill this script hit CRTL-C\n\n"
+   help = "NBT Name Service/LLMNR Answerer 2.0.\nPlease send bugs/comments to: lgaffie@trustwave.com\nTo kill this script hit CRTL-C\n\n"
    help+= ExtraHelpData
    print help
 


### PR DESCRIPTION
I changed the default permissions of Responder.py to +x so someone could execute responder without having to call python directly.

Also changed to Responder 2.0 to match the release.
