### PR TITLE
Case-insensitive content-type check

### DIFF
--- a/Responder.py
+++ b/Responder.py
@@ -1498,7 +1498,7 @@ def InjectData(data):
              return Gzip
           else:
              return data
-       if "Content-Type: text/html" in Headers:
+       if "content-type: text/html" in Headers.lower():
           Len = ''.join(re.findall('(?<=Content-Length: )[^\r\n]*', Headers))
           HasHTML = re.findall('(?<=<html)[^<]*', Content)
           if HasHTML :


### PR DESCRIPTION
Was noticing that injection wasn't happening when the header was "Content-type" instead of the checked for "Content-Type". Headers could probably be put as .lower() from the beginning, but then again there might be header content that may break because of it.
