### PR TITLE
Fixes MDNS Name parsing error (Issue #47)

### DIFF
--- a/poisoners/MDNS.py
+++ b/poisoners/MDNS.py
@@ -49,7 +49,7 @@ class MDNS(BaseRequestHandler):
 		Request_Name = Parse_MDNS_Name(data)
 
 		# Break out if we don't want to respond to this host
-		if (not Request_name) or (RespondToThisHost(self.client_address[0], Request_Name) is not True):
+		if (not Request_Name) or (RespondToThisHost(self.client_address[0], Request_Name) is not True):
 			return None
 
 		try:

--- a/poisoners/MDNS.py
+++ b/poisoners/MDNS.py
@@ -49,7 +49,7 @@ class MDNS(BaseRequestHandler):
 		Request_Name = Parse_MDNS_Name(data)
 
 		# Break out if we don't want to respond to this host
-		if Request_name and RespondToThisHost(self.client_address[0], Request_Name) is not True:
+		if (not Request_name) or (RespondToThisHost(self.client_address[0], Request_Name) is not True):
 			return None
 
 		try:

--- a/poisoners/MDNS.py
+++ b/poisoners/MDNS.py
@@ -23,12 +23,15 @@ from packets import MDNS_Ans
 from utils import *
 
 def Parse_MDNS_Name(data):
-	data = data[12:]
-	NameLen = struct.unpack('>B',data[0])[0]
-	Name = data[1:1+NameLen]
-	NameLen_ = struct.unpack('>B',data[1+NameLen])[0]
-	Name_ = data[1+NameLen:1+NameLen+NameLen_+1]
-	return Name+'.'+Name_
+	try:
+		data = data[12:]
+		NameLen = struct.unpack('>B',data[0])[0]
+		Name = data[1:1+NameLen]
+		NameLen_ = struct.unpack('>B',data[1+NameLen])[0]
+		Name_ = data[1+NameLen:1+NameLen+NameLen_+1]
+		return Name+'.'+Name_
+	except IndexError:
+		return None
 
 def Poisoned_MDNS_Name(data):
 	data = data[12:]
@@ -46,7 +49,7 @@ class MDNS(BaseRequestHandler):
 		Request_Name = Parse_MDNS_Name(data)
 
 		# Break out if we don't want to respond to this host
-		if RespondToThisHost(self.client_address[0], Request_Name) is not True:
+		if Request_name and RespondToThisHost(self.client_address[0], Request_Name) is not True:
 			return None
 
 		try:


### PR DESCRIPTION
This should fix issue #47, the problem was that certain MDNS packets appear to be empty, for example here's a hexdump of one of the offending MDNS packets:
```
00000000:  00 00 84 00 00 00 00 00 00 00 00  00                                 |............|
```
The header is valid , but there is no payload, It's safe to assume these can be ignored so I added a try/except statement and a check in the ```handle()``` function