### PR TITLE
Fix generation of HTTP response in HTTP proxy

### DIFF
--- a/servers/HTTP_Proxy.py
+++ b/servers/HTTP_Proxy.py
@@ -65,12 +65,12 @@ def InjectData(data, client, req_uri):
 					print text("[PROXY] Injecting into HTTP Response: %s" % color(settings.Config.HtmlToInject, 3, 1))
 
 				Content = Content.replace(HasBody[0], '%s\n%s' % (HasBody[0], settings.Config.HtmlToInject))
-				Headers = Headers.replace("Content-Length: "+Len, "Content-Length: "+ str(len(Content)))
 
 		if "content-encoding: gzip" in Headers.lower():
 			Content = zlib.compress(Content)
 
-		data = Headers +'\r\n'+ Content
+		Headers = Headers.replace("Content-Length: "+Len, "Content-Length: "+ str(len(Content)))
+		data = Headers +'\r\n\r\n'+ Content
 
 	else:
 		if settings.Config.Verbose:


### PR DESCRIPTION
Two small bugs were stopping the WPAD proxy from rendering correct HTML pages:

1. The "Content-Length" calculation should be last, to account for responses that need to be compressed. This was not a blocker and browsers would just ignore the wrong length.
2. Headers and content should be separated by '\r\n\r\n', otherwise the page would not be rendered at all.

I tested this with updated Chrome and IE, but further testing might be required.

I thought it'd be a good idea to send this pull request to get the proxy working again.

Cheers.
