### PR TITLE
Cleartex log

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -171,7 +171,8 @@ def SaveToDb(result):
 
 	if count == 0:
 		
-		# Write JtR-style hash string to file
+                # If we obtained cleartext credentials, write them to file
+		# Otherwise, write JtR-style hash string to file
 		with open(logfile,"a") as outf:
 			if len(result['cleartext']):
 				outf.write('%s:%s' % (result['user'], result['cleartext']))

--- a/utils.py
+++ b/utils.py
@@ -173,7 +173,10 @@ def SaveToDb(result):
 		
 		# Write JtR-style hash string to file
 		with open(logfile,"a") as outf:
-			outf.write(result['fullhash'])
+			if len(result['cleartext']):
+				outf.write('%s:%s' % (result['user'], result['cleartext']))
+			else:
+				outf.write(result['fullhash'])
 			outf.write("\n")
 			outf.close()
 


### PR DESCRIPTION
Hi guys,

I noticed that there was a problem regarding logging of cleartext credentials. When the result of the capture is saved to the logfile, what is written is `result['fullhash']`.

However, if we captured cleartext credentials, using the -b switch for example, this value is empty. This is why we should write `result['cleartext']`.

We first check if `result['cleartext']` is empty or not. If it isn't, we write `result['user']:result['cleartext']` to the log file. Otherwise, we write the full hash, JtR-style.

Thank you for this great tool!

Cheers,

Yannick