### PR TITLE
Cleartext db encoding

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -166,6 +166,7 @@ def SaveToDb(result):
 	logfile = os.path.join(settings.Config.ResponderPATH, 'logs', fname)
 
 	cursor = sqlite3.connect(settings.Config.DatabaseFile)
+	cursor.text_factory = sqlite3.Binary
 	res = cursor.execute("SELECT COUNT(*) AS count FROM responder WHERE module=? AND type=? AND LOWER(user)=LOWER(?)", (result['module'], result['type'], result['user']))
 	(count,) = res.fetchone()
 

--- a/utils.py
+++ b/utils.py
@@ -166,6 +166,7 @@ def SaveToDb(result):
 	logfile = os.path.join(settings.Config.ResponderPATH, 'logs', fname)
 
 	cursor = sqlite3.connect(settings.Config.DatabaseFile)
+        # We add a text factory to support different charsets
 	cursor.text_factory = sqlite3.Binary
 	res = cursor.execute("SELECT COUNT(*) AS count FROM responder WHERE module=? AND type=? AND LOWER(user)=LOWER(?)", (result['module'], result['type'], result['user']))
 	(count,) = res.fetchone()


### PR DESCRIPTION
Hi guys,

a coworker and I noticed that Responder does not handle correctly the saving in the database of credentials with special characters (like, é, à, etc.). When we captured clear text credentials, with the -b switch, we obtained the following error:

```
Exception happened during processing of request from ('XXX.XXX.XXX.XXX', 61108)
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 599, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 655, in __init__
    self.handle()
  File "/home/yme/tools/Responder_the-useless-one/servers/HTTP.py", line 240, in handle
    Buffer = PacketSequence(data,self.client_address[0])
  File "/home/yme/tools/Responder_the-useless-one/servers/HTTP.py", line 198, in PacketSequence
    'cleartext': ClearText_Auth.split(':')[1],
  File "/home/yme/tools/Responder_the-useless-one/utils.py", line 169, in SaveToDb
    res = cursor.execute("SELECT COUNT(*) AS count FROM responder WHERE module=? AND type=? AND LOWER(user)=LOWER(?)", (result['module'], result['type'], result['user']))
ProgrammingError: You must not use 8-bit bytestrings unless you use a text_factory that can interpret 8-bit bytestrings (like text_factory = str). It is highly recommended that you instead just switch your application to Unicode strings.
```
We added a text_factory so that clear text credentials with different encodings can be saved in the database.

We chose `sqlite3.Binary` as advised by [this StackOverflow post](http://stackoverflow.com/questions/3425320/sqlite3-programmingerror-you-must-not-use-8-bit-bytestrings-unless-you-use-a-te#comment38220699_4020598).