### PR TITLE
Add HTTP Referer logging

### DIFF
--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -99,6 +99,17 @@ def GrabHost(data, host):
 	else:
 		return False
 
+def GrabReferer(data, host):
+	Referer = re.search('(Referer:*.\=*)[^\r\n]*', data)
+
+	if Referer:
+		Referer = Referer.group(0).replace('Referer: ', '')
+		if settings.Config.Verbose:
+			print text("[HTTP] Referer         : %s " % color(Referer, 3))
+		return Referer
+	else:
+		return False
+
 def WpadCustom(data, client):
 	Wpad = re.search('(/wpad.dat|/*\.pac)', data)
 	if Wpad:
@@ -159,6 +170,7 @@ def PacketSequence(data, client):
 
 		if Packet_NTLM == "\x01":
 			GrabURL(data, client)
+			GrabReferer(data, client)
 			GrabHost(data, client)
 			GrabCookie(data, client)
 
@@ -187,6 +199,7 @@ def PacketSequence(data, client):
 		ClearText_Auth = b64decode(''.join(Basic_Auth))
 
 		GrabURL(data, client)
+		GrabReferer(data, client)
 		GrabHost(data, client)
 		GrabCookie(data, client)
 


### PR DESCRIPTION
In some situations, a single URL pointing to Responder inserted in one field can automatically be included on multiple different URLs.

Logging the HTTP Referer header helps track the specific URLs the Responder link is being loaded from.