### PR TITLE
Threads now use the threading module, fixed CTRL-C and SSL socket issues

### DIFF
--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -279,27 +279,3 @@ class HTTPS(StreamRequestHandler):
 					self.exchange.send(Buffer)
 		except:
 			pass
-
-# SSL context handler
-class SSLSock(ThreadingMixIn, TCPServer):
-	def __init__(self, server_address, RequestHandlerClass):
-		from OpenSSL import SSL
-
-		BaseServer.__init__(self, server_address, RequestHandlerClass)
-		ctx = SSL.Context(SSL.SSLv3_METHOD)
-
-		cert = os.path.join(settings.Config.ResponderPATH, settings.Config.SSLCert)
-		key =  os.path.join(settings.Config.ResponderPATH, settings.Config.SSLKey)
-
-		ctx.use_privatekey_file(key)
-		ctx.use_certificate_file(cert)
-
-		self.socket = SSL.Connection(ctx, socket.socket(self.address_family, self.socket_type))
-		self.server_bind()
-		self.server_activate()
-
-	def shutdown_request(self,request):
-		try:
-			request.shutdown()
-		except:
-			pass


### PR DESCRIPTION
Heya,

This PR kills 3 birds with one stone!

All the threads are now spun up with the ```threading``` module as supposed to the ```thread``` module which has been deprecated a while ago. Additionally, all the threads should now exit immediately upon hitting CTRL-C (addresses issue #51) . Also, I've been running into issues with the SSL server on Arch Linux, ```pyOpenSSL``` doesn't seem to be very cooperative, I yanked it out in favor of the built-in ```ssl``` module which should resolve all the issues related to that as well.

Cheers