### PR TITLE
Implemented auto-ignore list

### DIFF
--- a/Responder.conf
+++ b/Responder.conf
@@ -45,6 +45,9 @@ DontRespondTo =
 ; Example: DontRespondTo = NAC, IPS, IDS
 DontRespondToName =
 
+; If set to On, we will stop answering further requests from a host
+; if a hash hash been previously captured for this host.
+AutoIgnoreAfterSuccess = On
 
 [HTTP Server]
 
@@ -52,7 +55,7 @@ DontRespondToName =
 Serve-Always = Off
 
 ; Set to On to replace any requested .exe with the custom EXE
-Serve-Exe = On
+Serve-Exe = Off
 
 ; Set to On to serve the custom HTML if the URL does not contain .exe
 ; Set to Off to inject the 'HTMLToInject' in web pages instead

--- a/settings.py
+++ b/settings.py
@@ -148,6 +148,10 @@ class Settings:
 		self.DontRespondTo     = filter(None, [x.upper().strip() for x in config.get('Responder Core', 'DontRespondTo').strip().split(',')])
 		self.DontRespondToName = filter(None, [x.upper().strip() for x in config.get('Responder Core', 'DontRespondToName').strip().split(',')])
 
+		# Auto Ignore List
+		self.AutoIgnore        = self.toBool(config.get('Responder Core', 'AutoIgnoreAfterSuccess'))
+		self.AutoIgnoreList    = []
+
 		# CLI options
 		self.LM_On_Off       = options.LM_On_Off
 		self.WPAD_On_Off     = options.WPAD_On_Off
@@ -156,7 +160,7 @@ class Settings:
 		self.Basic           = options.Basic
 		self.Finger_On_Off   = options.Finger
 		self.Interface       = options.Interface
-                self.OURIP           = options.OURIP
+		self.OURIP           = options.OURIP
 		self.Force_WPAD_Auth = options.Force_WPAD_Auth
 		self.Upstream_Proxy  = options.Upstream_Proxy
 		self.AnalyzeMode     = options.Analyze

--- a/utils.py
+++ b/utils.py
@@ -55,6 +55,10 @@ def RespondToThisIP(ClientIp):
 	if ClientIp.startswith('127.0.0.'):
 		return False
 
+	if settings.Config.AutoIgnore and ClientIp in settings.Config.AutoIgnoreList:
+		print color('[*]', 3, 1), 'Received request from auto-ignored client %s, not answering.' % ClientIp
+		return False
+
 	if len(settings.Config.RespondTo) and ClientIp not in settings.Config.RespondTo:
 		return False
 
@@ -171,7 +175,7 @@ def SaveToDb(result):
 
 	if count == 0:
 		
-                # If we obtained cleartext credentials, write them to file
+		# If we obtained cleartext credentials, write them to file
 		# Otherwise, write JtR-style hash string to file
 		with open(logfile,"a") as outf:
 			if len(result['cleartext']):
@@ -204,9 +208,16 @@ def SaveToDb(result):
 			print text("[%s] %s Hash     : %s" % (result['module'], result['type'], color(result['fullhash'], 3)))
 		elif len(result['hash']):
 			print text("[%s] %s Hash     : %s" % (result['module'], result['type'], color(result['hash'], 3)))
-			
+
+		# Appending auto-ignore list if required
+		# Except if this is a machine account's hash
+		if settings.Config.AutoIgnore and not result['user'].endswith('$'):
+
+			settings.Config.AutoIgnoreList.append(result['client'])
+			print color('[*] Adding client %s to auto-ignore list' % result['client'], 4, 1)
+
 	else:
-		print color('[*]', 2, 1), 'Skipping previously captured hash for %s' % result['user']
+		print color('[*]', 3, 1), 'Skipping previously captured hash for %s' % result['user']
 
 
 def Parse_IPV6_Addr(data):


### PR DESCRIPTION
This implements #78 

This way you can leave responder running in the background and not worry about disturbing things too much for any given user. Once a user hash (excepted machine hashes) has been captured, no further poisoned answers will be sent to the source IP.

Because multiple users can use one given workstation, the option can be disabled from the config file (though enabled by default).

PS: I also disabled the default setting of "Serving Exe", I believe it makes more sense to enable it manually if required. I have accidentally sent a bindshell without realising that the option was enabled :-/