### PR TITLE
Gather multiple credentials

### DIFF
--- a/Responder.conf
+++ b/Responder.conf
@@ -49,6 +49,11 @@ DontRespondToName =
 ; if a hash hash been previously captured for this host.
 AutoIgnoreAfterSuccess = Off
 
+; If set to On, we will send ACCOUNT_DISABLED when the client tries
+; to authenticate for the first time to try to get different credentials.
+; This may break file serving and is useful only for hash capture
+CaptureMultipleCredentials = Off
+
 [HTTP Server]
 
 ; Set to On to always serve the custom EXE

--- a/settings.py
+++ b/settings.py
@@ -146,8 +146,9 @@ class Settings:
 		self.DontRespondToName = filter(None, [x.upper().strip() for x in config.get('Responder Core', 'DontRespondToName').strip().split(',')])
 
 		# Auto Ignore List
-		self.AutoIgnore        = self.toBool(config.get('Responder Core', 'AutoIgnoreAfterSuccess'))
-		self.AutoIgnoreList    = []
+		self.AutoIgnore                 = self.toBool(config.get('Responder Core', 'AutoIgnoreAfterSuccess'))
+		self.CaptureMultipleCredentials = self.toBool(config.get('Responder Core', 'CaptureMultipleCredentials'))
+		self.AutoIgnoreList             = []
 
 		# CLI options
 		self.LM_On_Off       = options.LM_On_Off


### PR DESCRIPTION
Send ACCOUNT_DISABLED on the first SMB authentication to gather multiple credentials if there are any. If the victim is connected to the VPN (IPsec, PPTP, L2TP) with MSCHAPv2 authentication, we'll get both VPN credentials and Windows credentials.