### PR TITLE
change IsOSX to utils.IsOsX. Fixes #89

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -65,7 +65,7 @@ class Settings:
 
 	def populate(self, options):
 
-		if options.Interface is None and IsOsX() is False:
+		if options.Interface is None and utils.IsOsX() is False:
 			print utils.color("Error: -I <if> mandatory option is missing", 1)
 			sys.exit(-1)
 


### PR DESCRIPTION
Fixes an issue that causes Responder to error out on various linuxes. Seems to only be an issue when an interface isn't specified.

```
jared@localhost ~/r/w/Responder> sudo ./Responder.py
                                         __
  .----.-----.-----.-----.-----.-----.--|  |.-----.----.
  |   _|  -__|__ --|  _  |  _  |     |  _  ||  -__|   _|
  |__| |_____|_____|   __|_____|__|__|_____||_____|__|
                   |__|

           NBT-NS, LLMNR & MDNS Responder 2.3

  Author: Laurent Gaffie (laurent.gaffie@gmail.com)
  To kill this script hit CRTL-C

Traceback (most recent call last):
  File "./Responder.py", line 50, in <module>
    settings.Config.populate(options)
  File "/home/jared/repos/work/Responder/settings.py", line 68, in populate
    if options.Interface is None and IsOsX() is False:
NameError: global name 'IsOsX' is not defined
```

With this fix in place, users get the expected "missing -I <if>" error message.

```
jared@localhost ~/r/w/Responder> sudo ./Responder.py
                                         __
  .----.-----.-----.-----.-----.-----.--|  |.-----.----.
  |   _|  -__|__ --|  _  |  _  |     |  _  ||  -__|   _|
  |__| |_____|_____|   __|_____|__|__|_____||_____|__|
                   |__|

           NBT-NS, LLMNR & MDNS Responder 2.3

  Author: Laurent Gaffie (laurent.gaffie@gmail.com)
  To kill this script hit CRTL-C

Error: -I <if> mandatory option is missing
```