### PR TITLE
Proper non-Latin names support for SMB

### DIFF
--- a/servers/SMB.py
+++ b/servers/SMB.py
@@ -65,7 +65,7 @@ def ParseShare(data):
 	packet = data[:]
 	a = re.search('(\\x5c\\x00\\x5c.*.\\x00\\x00\\x00)', packet)
 	if a:
-		print text("[SMB] Requested Share     : %s" % a.group(0).replace('\x00', ''))
+		print text("[SMB] Requested Share     : %s" % a.group(0).decode('UTF-16LE'))
 
 
 def ParseSMBHash(data,client):  #Parse SMB NTLMSSP v1/v2
@@ -91,10 +91,10 @@ def ParseSMBHash(data,client):  #Parse SMB NTLMSSP v1/v2
 		SMBHash      = SSPIStart[NthashOffset:NthashOffset+NthashLen].encode("hex").upper()
 		DomainLen    = struct.unpack('<H',data[105:107])[0]
 		DomainOffset = struct.unpack('<H',data[107:109])[0]
-		Domain       = SSPIStart[DomainOffset:DomainOffset+DomainLen].replace('\x00','')
+		Domain       = SSPIStart[DomainOffset:DomainOffset+DomainLen].decode('UTF-16LE')
 		UserLen      = struct.unpack('<H',data[113:115])[0]
 		UserOffset   = struct.unpack('<H',data[115:117])[0]
-		Username     = SSPIStart[UserOffset:UserOffset+UserLen].replace('\x00','')
+		Username     = SSPIStart[UserOffset:UserOffset+UserLen].decode('UTF-16LE')
 		WriteHash    = '%s::%s:%s:%s:%s' % (Username, Domain, LMHash, SMBHash, settings.Config.NumChal)
 
 		SaveToDb({
@@ -110,10 +110,10 @@ def ParseSMBHash(data,client):  #Parse SMB NTLMSSP v1/v2
 		SMBHash      = SSPIStart[NthashOffset:NthashOffset+NthashLen].encode("hex").upper()
 		DomainLen    = struct.unpack('<H',data[109:111])[0]
 		DomainOffset = struct.unpack('<H',data[111:113])[0]
-		Domain       = SSPIStart[DomainOffset:DomainOffset+DomainLen].replace('\x00','')
+		Domain       = SSPIStart[DomainOffset:DomainOffset+DomainLen].decode('UTF-16LE')
 		UserLen      = struct.unpack('<H',data[117:119])[0]
 		UserOffset   = struct.unpack('<H',data[119:121])[0]
-		Username     = SSPIStart[UserOffset:UserOffset+UserLen].replace('\x00','')
+		Username     = SSPIStart[UserOffset:UserOffset+UserLen].decode('UTF-16LE')
 		WriteHash    = '%s::%s:%s:%s:%s' % (Username, Domain, settings.Config.NumChal, SMBHash[:32], SMBHash[32:])
 
 		SaveToDb({

--- a/utils.py
+++ b/utils.py
@@ -154,9 +154,9 @@ def SaveToDb(result):
 	if not count:
 		with open(logfile,"a") as outf:
 			if len(result['cleartext']):  # If we obtained cleartext credentials, write them to file
-				outf.write('%s:%s\n' % (result['user'], result['cleartext']))
+				outf.write('%s:%s\n' % (result['user'].encode('utf8', 'replace'), result['cleartext'].encode('utf8', 'replace')))
 			else:  # Otherwise, write JtR-style hash string to file
-				outf.write(result['fullhash'] + '\n')
+				outf.write(result['fullhash'].encode('utf8', 'replace') + '\n')
 
 		cursor.execute("INSERT INTO responder VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)", (timestamp, result['module'], result['type'], result['client'], result['hostname'], result['user'], result['cleartext'], result['hash'], result['fullhash']))
 		cursor.commit()


### PR DESCRIPTION
Currently Responder uses an amazingly bad hack to "convert" UTF-16LE names from the SMB packet to ascii-sh names by stripping \x00 out of the name. This works only for Latin names. This patch properly handles UTF-16 encoded data and re-encodes it to UTF-8 to store in Responder.db and log file.