### PR TITLE
Fixed the regexes for Authorization: headers.

### DIFF
--- a/servers/HTTP.py
+++ b/servers/HTTP.py
@@ -144,8 +144,8 @@ def GrabURL(data, host):
 
 # Handle HTTP packet sequence.
 def PacketSequence(data, client):
-	NTLM_Auth = re.findall(r'(?<=Authorization: NTLM )[^\\r]*', data)
-	Basic_Auth = re.findall(r'(?<=Authorization: Basic )[^\\r]*', data)
+	NTLM_Auth = re.findall(r'(?<=Authorization: NTLM )[^\r]*', data)
+	Basic_Auth = re.findall(r'(?<=Authorization: Basic )[^\r]*', data)
 
 	# Serve the .exe if needed
 	if settings.Config.Serve_Always is True or (settings.Config.Serve_Exe is True and re.findall('.exe', data)):


### PR DESCRIPTION
The \r was escaped inside a character class where it did not need to be.
Instead of the search stopping at the first \r as intended, it stopped
at the first literal r (which can occur in normal b64 content) or the
first literal \ (unlikely to occur in HTTP headers in general).

The \\ has been there since the very first commit of Responder in 2013.