### PR TITLE
Update utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -87,7 +87,7 @@ def OsInterfaceIsSupported():
 def IsOsX():
 	return sys.platform == "darwin"
 
-def FindLocalIP(Iface, OURIP):
+def FindLocalIP(Iface, OURIP=None):
 	if Iface == 'ALL':
 		return '0.0.0.0'
 


### PR DESCRIPTION
Set default value for 2nd input var on FindLocalIP in order to maintain (backwards)compatibility with DHCP.py (call's with 1 param).

Not sure if this branch is kept in sync with lgandx, see pull request for maintained branch here: 
https://github.com/lgandx/Responder/pull/10