### PR TITLE
Implement custom config command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 LLMNR/NBT-NS/mDNS Poisoner
 
-This version is now unsupported by the author. For latest push/fixes/updates use the official repository: https://github.com/lgandx/Responder
+This version is now unsupported by the author. 
+
+For latest push/fixes/updates use the official repository: https://github.com/lgandx/Responder
 
 Author: Laurent Gaffie < laurent.gaffie@gmail.com >  
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 LLMNR/NBT-NS/mDNS Poisoner
 
-Author: Laurent Gaffie <laurent.gaffie@gmail.com >  
+This version is now unsupported by the author. For latest push/fixes/updates use the official repository: https://github.com/lgandx/Responder
+
+Author: Laurent Gaffie < laurent.gaffie@gmail.com >  
 
 https://g-laurent.blogspot.com/ 
 
@@ -157,7 +159,7 @@ Options:
 
 
 
-## Copyright ##
+## License ##
 
 NBT-NS/LLMNR Responder
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Edit this file /etc/NetworkManager/NetworkManager.conf and comment the line: `dn
 
 - For OSX, please note: Responder must be launched with an IP address for the -i flag (e.g. -i YOUR_IP_ADDR). There is no native support in OSX for custom interface binding. Using -i en1 will not work. Also to run Responder with the best experience, run the following as root:
 
-    launchcl unload /System/Library/LaunchDaemons/com.apple.Kerberos.kdc.plist
+    launchctl unload /System/Library/LaunchDaemons/com.apple.Kerberos.kdc.plist
 
     launchctl unload /System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 LLMNR/NBT-NS/mDNS Poisoner
 
-Author: Laurent Gaffie <laurent.gaffie@gmail.com > http://www.spiderlabs.com
+Author: Laurent Gaffie <laurent.gaffie@gmail.com >  
 
+https://g-laurent.blogspot.com/ 
 
 
 ## Intro ##
@@ -159,8 +160,9 @@ Options:
 ## Copyright ##
 
 NBT-NS/LLMNR Responder
-Created by Laurent Gaffie
-Copyright (C) 2013 Trustwave Holdings, Inc.
+
+Created and maintained by Laurent Gaffie
+
  
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Options:
 	                        False
 	  --lm                  Force LM hashing downgrade for Windows XP/2003 and
 	                        earlier. Default: False
+	  -c, --config          Specify the location of a custom Responder.conf file to use. Default: ./Responder.conf
 	  -v, --verbose         Increase verbosity.
 	
 

--- a/Responder.py
+++ b/Responder.py
@@ -35,8 +35,8 @@ parser.add_option('-w','--wpad',           action="store_true", help="Start the 
 parser.add_option('-u','--upstream-proxy', action="store",      help="Upstream HTTP proxy used by the rogue WPAD Proxy for outgoing requests (format: host:port)", dest="Upstream_Proxy", default=None)
 parser.add_option('-F','--ForceWpadAuth',  action="store_true", help="Force NTLM/Basic authentication on wpad.dat file retrieval. This may cause a login prompt. Default: False", dest="Force_WPAD_Auth", default=False)
 parser.add_option('--lm',                  action="store_true", help="Force LM hashing downgrade for Windows XP/2003 and earlier. Default: False", dest="LM_On_Off", default=False)
-parser.add_option('-v','--verbose',        action="store_true", help="Increase verbosity.", dest="Verbose")
 parser.add_option('-c', '--config',        action="store",      help="Specify the location of a custom Responder.conf file to use. Default: ./Responder.conf", dest="Conf_path", default=None)
+parser.add_option('-v','--verbose',        action="store_true", help="Increase verbosity.", dest="Verbose")
 options, args = parser.parse_args()
 
 if not os.geteuid() == 0:

--- a/Responder.py
+++ b/Responder.py
@@ -36,6 +36,7 @@ parser.add_option('-u','--upstream-proxy', action="store",      help="Upstream H
 parser.add_option('-F','--ForceWpadAuth',  action="store_true", help="Force NTLM/Basic authentication on wpad.dat file retrieval. This may cause a login prompt. Default: False", dest="Force_WPAD_Auth", default=False)
 parser.add_option('--lm',                  action="store_true", help="Force LM hashing downgrade for Windows XP/2003 and earlier. Default: False", dest="LM_On_Off", default=False)
 parser.add_option('-v','--verbose',        action="store_true", help="Increase verbosity.", dest="Verbose")
+parser.add_option('-c', '--config',        action="store",      help="Specify the location of a custom Responder.conf file to use. Default: ./Responder.conf", dest="Conf_path", default=None)
 options, args = parser.parse_args()
 
 if not os.geteuid() == 0:

--- a/settings.py
+++ b/settings.py
@@ -69,9 +69,12 @@ class Settings:
 			print utils.color("Error: -I <if> mandatory option is missing", 1)
 			sys.exit(-1)
 
-		# Config parsing
+		# Config parsing - If a config file path has been supplied then use it, otherwise use the local Responder.conf file.
 		config = ConfigParser.ConfigParser()
-		config.read(os.path.join(self.ResponderPATH, 'Responder.conf'))
+		if options.Conf_path is None:
+		    config.read(os.path.join(self.ResponderPATH, 'Responder.conf'))
+		else:
+		    config.read(options.Conf_path)
 
 		# Servers
 		self.HTTP_On_Off     = self.toBool(config.get('Responder Core', 'HTTP'))


### PR DESCRIPTION
This change allows a user to specify the location of a custom Responder.conf file using the command line. This is useful when Responder is being used in conjunction with other scripted tools (such as Proxenet, or Fake-AP) where specific options are desired without the need to change the base Responder.conf file.