### PR TITLE
Fixed small typo

### DIFF
--- a/tools/Icmp-Redirect.py
+++ b/tools/Icmp-Redirect.py
@@ -215,7 +215,7 @@ def IcmpRedirectSock(DestinationIP):
 
 def FindWhatToDo(ToThisHost2):
     if ToThisHost2 != None:
-        Show_Help('Hit CRTL-C to kill this script')
+        Show_Help('Hit CTRL-C to kill this script')
         RunThisInLoop(ToThisHost, ToThisHost2,OURIP)
     if ToThisHost2 == None:
         Show_Help(MoreHelp)

--- a/tools/SMBRelay.py
+++ b/tools/SMBRelay.py
@@ -75,7 +75,7 @@ Responder_IP = options.Responder_IP
 
 print "\nResponder SMBRelay 0.1\nPlease send bugs/comments to: laurent.gaffie@gmail.com"
 print '\033[31m'+'Use this script in combination with Responder.py for best results (remember to set SMB = Off in Responder.conf)..\nUsernames  to relay (-u) are case sensitive.'+'\033[0m'
-print 'To kill this script hit CRTL-C or Enter\nWill relay credentials for these users: '+'\033[1m\033[34m'+', '.join(UserToRelay)+'\033[0m\n'
+print 'To kill this script hit CTRL-C or Enter\nWill relay credentials for these users: '+'\033[1m\033[34m'+', '.join(UserToRelay)+'\033[0m\n'
 
 #Function used to verify if a previous auth attempt was made.
 def ReadData(outfile,Client, User, cmd=None):

--- a/utils.py
+++ b/utils.py
@@ -239,7 +239,7 @@ def banner():
 	print "\n           \033[1;33mNBT-NS, LLMNR & MDNS %s\033[0m" % settings.__version__
 	print ""
 	print "  Author: Laurent Gaffie (laurent.gaffie@gmail.com)"
-	print "  To kill this script hit CRTL-C"
+	print "  To kill this script hit CTRL-C"
 	print ""
 
 


### PR DESCRIPTION
This has been bugging me ever since I started using Responder.

This PR replaces all instances of "CRTL-C" with the corrected version "CTRL-C".

You're welcome.