### PR TITLE
Fix Typo in macOS Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Edit this file /etc/NetworkManager/NetworkManager.conf and comment the line: `dn
 
 - For OSX, please note: Responder must be launched with an IP address for the -i flag (e.g. -i YOUR_IP_ADDR). There is no native support in OSX for custom interface binding. Using -i en1 will not work. Also to run Responder with the best experience, run the following as root:
 
-    launchcl unload /System/Library/LaunchDaemons/com.apple.Kerberos.kdc.plist
+    launchctl unload /System/Library/LaunchDaemons/com.apple.Kerberos.kdc.plist
 
     launchctl unload /System/Library/LaunchDaemons/com.apple.mDNSResponder.plist
 


### PR DESCRIPTION
There was a minor typo in a macOS command that caused "launchctl" to appear as "launchcl".